### PR TITLE
* BatchedDBJob용 브랜치 생성

### DIFF
--- a/RIO_Test/DBClient.cpp
+++ b/RIO_Test/DBClient.cpp
@@ -85,3 +85,13 @@ void DBClient::CallProcedure(CSerializationBuf& packet)
 {
 	CMultiLanClient::SendPacket(&packet);
 }
+
+void DBClient::SendPacket(CSerializationBuf& packet)
+{
+	CMultiLanClient::SendPacket(&packet);
+}
+
+void DBClient::SendPacketToFixedChannel(CSerializationBuf& packet, UINT64 sessionId)
+{
+	CMultiLanClient::SendPacket(&packet, sessionId);
+}

--- a/RIO_Test/DBClient.h
+++ b/RIO_Test/DBClient.h
@@ -31,6 +31,8 @@ public:
 
 public:
 	void CallProcedure(CSerializationBuf& packet);
+	void SendPacket(CSerializationBuf& packet);
+	void SendPacketToFixedChannel(CSerializationBuf& packet, UINT64 sessionId);
 
 private:
 

--- a/RIO_Test/DBJob.h
+++ b/RIO_Test/DBJob.h
@@ -11,7 +11,7 @@ class RIOTestSession;
 
 class DBJob
 {
-	friend BatchedDBJob;
+	friend class BatchedDBJob;
 
 public:
 	DBJob() = delete;
@@ -30,13 +30,13 @@ private:
 
 private:
 	CSerializationBuf* jobSPBuffer = nullptr;
-	unsigned char batchedNo = 0;
 };
 
 class BatchedDBJob
 {
 public:
-	BatchedDBJob() = default;
+	BatchedDBJob() = delete;
+	explicit BatchedDBJob(std::shared_ptr<RIOTestSession> inOwner);
 	virtual ~BatchedDBJob() = default;
 
 public:
@@ -48,6 +48,7 @@ public:
 
 private:
 	std::list<std::shared_ptr<DBJob>> jobList;
+	std::shared_ptr<RIOTestSession> owner = nullptr;
 };
 
 class GlobalDBJob : public DBJob

--- a/RIO_Test/MultiLanClient.h
+++ b/RIO_Test/MultiLanClient.h
@@ -32,7 +32,14 @@ public:
 	bool Start(const WCHAR* szOptionFileName);
 	void Stop();
 
+public:
 	bool SendPacket(CSerializationBuf* pSerializeBuf);
+	bool SendPacket(CSerializationBuf* pSerializeBuf, UINT64 fixedId);
+
+private:
+	bool SendPacketImpl(CSerializationBuf* pSerializeBuf, UINT64 channelId);
+
+public:
 	// 서버에 Connect 가 완료 된 후
 	virtual void OnConnectionComplete() = 0;
 
@@ -95,6 +102,7 @@ private:
 
 private:
 	UINT64 GetChannelId();
+	UINT64 GetFixedChannelId(UINT64 fixedId);
 
 private:
 	BYTE		m_byNumOfWorkerThread;


### PR DESCRIPTION
* MultiLanClient에서 DB로 패킷을 보낼 때, 패킷 순서를 보장하기 위해서, 세션의 Id를 받고 그에 따라 채널을 선택하여 송신하는 함수 추가 ** 함수가 두개로 나뉘어져서 공통 부문을 SendPacketImpl()로 묶음
* 송신 순서가 보장되게 수정 하였으므로, DBJob::batchedNo 제거
* BatchedDBJob()이 실행될 때, 리스트의 크기와 batch가 시작된다는 것을 알리는 패킷 먼저 송신하도록 수정
* DBServer로 부터 완료 통지를 받을 때는 이미 batch의 크기를 알고 있으므로, BatchedJob에 대한 완료 패킷은 받지 않음